### PR TITLE
Upgrade to 2.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.blend
+*.blend1


### PR DESCRIPTION
- Convert shadeless/material properties to 2.8 nodes
- combined 2 files into 1 (I have no idea how to run them without
installing the addon as 2 files; it's just easier. 2nd file is really
small anyway)
- Added .gitignore with *.blend/1 so I could easily play with my .blend files in the same directory.

Notes:
- I don't really know how it was suppose to work in 2.79 so I don't really know if it's working as intended. However the Create Data button creates the simulation and the simulation seems to work

I suggest you create a 2.8 branch and merge this PR into there, then see if there are any other issues.